### PR TITLE
Feature/updates for latest orizuru version

### DIFF
--- a/doc/com/financialforce/orizuru/AbstractConsumer.html
+++ b/doc/com/financialforce/orizuru/AbstractConsumer.html
@@ -384,6 +384,6 @@ implements <a href="../../../com/financialforce/orizuru/interfaces/IConsumer.htm
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/AbstractPublisher.html
+++ b/doc/com/financialforce/orizuru/AbstractPublisher.html
@@ -366,6 +366,6 @@ implements <a href="../../../com/financialforce/orizuru/interfaces/IPublisher.ht
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/class-use/AbstractConsumer.html
+++ b/doc/com/financialforce/orizuru/class-use/AbstractConsumer.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/class-use/AbstractPublisher.html
+++ b/doc/com/financialforce/orizuru/class-use/AbstractPublisher.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/OrizuruException.html
+++ b/doc/com/financialforce/orizuru/exception/OrizuruException.html
@@ -265,6 +265,6 @@ extends <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Exception.ht
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/class-use/OrizuruException.html
+++ b/doc/com/financialforce/orizuru/exception/class-use/OrizuruException.html
@@ -349,6 +349,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/OrizuruConsumerException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/OrizuruConsumerException.html
@@ -270,6 +270,6 @@ extends <a href="../../../../../com/financialforce/orizuru/exception/OrizuruExce
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/class-use/OrizuruConsumerException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/class-use/OrizuruConsumerException.html
@@ -176,14 +176,14 @@
 <tbody>
 <tr class="altColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><span class="typeNameLabel">Message.</span><code><span class="memberNameLink"><a href="../../../../../../com/financialforce/orizuru/message/Message.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
-<div class="block">Decode the message from the transport.</div>
+<td class="colLast"><span class="typeNameLabel">Context.</span><code><span class="memberNameLink"><a href="../../../../../../com/financialforce/orizuru/message/Context.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
+<div class="block">Decode the context from the transport.</div>
 </td>
 </tr>
 <tr class="rowColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><span class="typeNameLabel">Context.</span><code><span class="memberNameLink"><a href="../../../../../../com/financialforce/orizuru/message/Context.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
-<div class="block">Decode the context from the transport.</div>
+<td class="colLast"><span class="typeNameLabel">Message.</span><code><span class="memberNameLink"><a href="../../../../../../com/financialforce/orizuru/message/Message.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
+<div class="block">Decode the message from the transport.</div>
 </td>
 </tr>
 </tbody>
@@ -240,6 +240,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeContextException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeContextException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/consumer
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageContentException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageContentException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/consumer
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/consumer
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeTransportException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/DecodeTransportException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/consumer
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeContextException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeContextException.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeMessageContentException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeMessageContentException.html
@@ -164,6 +164,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeMessageException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeMessageException.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeTransportException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/class-use/DecodeTransportException.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/package-summary.html
@@ -167,6 +167,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/package-tree.html
@@ -152,6 +152,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/decode/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/decode/package-use.html
@@ -157,6 +157,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/handler/HandleMessageException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/handler/HandleMessageException.html
@@ -287,6 +287,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/consumer
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/handler/class-use/HandleMessageException.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/handler/class-use/HandleMessageException.html
@@ -163,6 +163,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/handler/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/handler/package-summary.html
@@ -149,6 +149,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/handler/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/handler/package-tree.html
@@ -149,6 +149,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/handler/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/handler/package-use.html
@@ -157,6 +157,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/package-summary.html
@@ -149,6 +149,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/package-tree.html
@@ -145,6 +145,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/consumer/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/consumer/package-use.html
@@ -203,6 +203,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/package-summary.html
@@ -149,6 +149,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/package-tree.html
@@ -141,6 +141,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/package-use.html
@@ -295,6 +295,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/OrizuruPublisherException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/OrizuruPublisherException.html
@@ -282,6 +282,6 @@ extends <a href="../../../../../com/financialforce/orizuru/exception/OrizuruExce
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/class-use/OrizuruPublisherException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/class-use/OrizuruPublisherException.html
@@ -195,6 +195,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/EncodeMessageContentException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/EncodeMessageContentException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/publishe
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/EncodeTransportException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/EncodeTransportException.html
@@ -269,6 +269,6 @@ extends <a href="../../../../../../com/financialforce/orizuru/exception/publishe
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/class-use/EncodeMessageContentException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/class-use/EncodeMessageContentException.html
@@ -164,6 +164,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/class-use/EncodeTransportException.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/class-use/EncodeTransportException.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/package-summary.html
@@ -155,6 +155,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/package-tree.html
@@ -150,6 +150,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/encode/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/encode/package-use.html
@@ -157,6 +157,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/package-summary.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/package-summary.html
@@ -149,6 +149,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/package-tree.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/package-tree.html
@@ -145,6 +145,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/exception/publisher/package-use.html
+++ b/doc/com/financialforce/orizuru/exception/publisher/package-use.html
@@ -180,6 +180,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/IConsumer.html
+++ b/doc/com/financialforce/orizuru/interfaces/IConsumer.html
@@ -246,6 +246,6 @@ extends <a href="../../../../com/financialforce/orizuru/interfaces/IQueueable.ht
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/IPublisher.html
+++ b/doc/com/financialforce/orizuru/interfaces/IPublisher.html
@@ -255,6 +255,6 @@ extends <a href="../../../../com/financialforce/orizuru/interfaces/IQueueable.ht
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/IQueueable.html
+++ b/doc/com/financialforce/orizuru/interfaces/IQueueable.html
@@ -230,6 +230,6 @@ var activeTableTab = "activeTableTab";
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/class-use/IConsumer.html
+++ b/doc/com/financialforce/orizuru/interfaces/class-use/IConsumer.html
@@ -164,6 +164,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/class-use/IPublisher.html
+++ b/doc/com/financialforce/orizuru/interfaces/class-use/IPublisher.html
@@ -177,6 +177,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/class-use/IQueueable.html
+++ b/doc/com/financialforce/orizuru/interfaces/class-use/IQueueable.html
@@ -202,6 +202,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/package-summary.html
+++ b/doc/com/financialforce/orizuru/interfaces/package-summary.html
@@ -161,6 +161,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/package-tree.html
+++ b/doc/com/financialforce/orizuru/interfaces/package-tree.html
@@ -134,6 +134,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/interfaces/package-use.html
+++ b/doc/com/financialforce/orizuru/interfaces/package-use.html
@@ -190,6 +190,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/Context.html
+++ b/doc/com/financialforce/orizuru/message/Context.html
@@ -181,7 +181,7 @@ extends <a href="../../../../com/financialforce/orizuru/message/Message.html" ti
 <!--   -->
 </a>
 <h3>Methods inherited from class&nbsp;com.financialforce.orizuru.message.<a href="../../../../com/financialforce/orizuru/message/Message.html" title="class in com.financialforce.orizuru.message">Message</a></h3>
-<code><a href="../../../../com/financialforce/orizuru/message/Message.html#decode--">decode</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#encode-O-">encode</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getData--">getData</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getDataBuffer--">getDataBuffer</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getSchema--">getSchema</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getSchemaName--">getSchemaName</a></code></li>
+<code><a href="../../../../com/financialforce/orizuru/message/Message.html#decode--">decode</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#encode-O-">encode</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getData--">getData</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getDataBuffer--">getDataBuffer</a>, <a href="../../../../com/financialforce/orizuru/message/Message.html#getSchema--">getSchema</a></code></li>
 </ul>
 <ul class="blockList">
 <li class="blockList"><a name="methods.inherited.from.class.java.lang.Object">
@@ -310,6 +310,6 @@ extends <a href="../../../../com/financialforce/orizuru/message/Message.html" ti
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/Message.html
+++ b/doc/com/financialforce/orizuru/message/Message.html
@@ -18,7 +18,7 @@
     catch(err) {
     }
 //-->
-var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10,"i6":10};
+var methods = {"i0":10,"i1":10,"i2":10,"i3":10,"i4":10,"i5":10};
 var tabs = {65535:["t0","All Methods"],2:["t2","Instance Methods"],8:["t4","Concrete Methods"]};
 var altColor = "altColor";
 var rowColor = "rowColor";
@@ -212,10 +212,6 @@ extends <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Object.html?
 <td class="colFirst"><code>org.apache.avro.Schema</code></td>
 <td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/message/Message.html#getSchema--">getSchema</a></span>()</code>&nbsp;</td>
 </tr>
-<tr id="i6" class="altColor">
-<td class="colFirst"><code><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/message/Message.html#getSchemaName--">getSchemaName</a></span>()</code>&nbsp;</td>
-</tr>
 </table>
 <ul class="blockList">
 <li class="blockList"><a name="methods.inherited.from.class.java.lang.Object">
@@ -381,19 +377,6 @@ extends <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Object.html?
 </dl>
 </li>
 </ul>
-<a name="getSchemaName--">
-<!--   -->
-</a>
-<ul class="blockList">
-<li class="blockList">
-<h4>getSchemaName</h4>
-<pre>public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;getSchemaName()</pre>
-<dl>
-<dt><span class="returnLabel">Returns:</span></dt>
-<dd>the schema name</dd>
-</dl>
-</li>
-</ul>
 <a name="getDataBuffer--">
 <!--   -->
 </a>
@@ -476,6 +459,6 @@ extends <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Object.html?
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/class-use/Context.html
+++ b/doc/com/financialforce/orizuru/message/class-use/Context.html
@@ -195,6 +195,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/class-use/Message.html
+++ b/doc/com/financialforce/orizuru/message/class-use/Message.html
@@ -164,6 +164,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/package-summary.html
+++ b/doc/com/financialforce/orizuru/message/package-summary.html
@@ -155,6 +155,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/package-tree.html
+++ b/doc/com/financialforce/orizuru/message/package-tree.html
@@ -137,6 +137,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/message/package-use.html
+++ b/doc/com/financialforce/orizuru/message/package-use.html
@@ -203,6 +203,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/package-summary.html
+++ b/doc/com/financialforce/orizuru/package-summary.html
@@ -158,6 +158,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/package-tree.html
+++ b/doc/com/financialforce/orizuru/package-tree.html
@@ -134,6 +134,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/package-use.html
+++ b/doc/com/financialforce/orizuru/package-use.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/Transport.Builder.html
+++ b/doc/com/financialforce/orizuru/transport/Transport.Builder.html
@@ -173,8 +173,8 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 </tr>
 <tr id="i4" class="altColor">
 <td class="colFirst"><code><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchemaName--">clearMessageSchemaName</a></span>()</code>
-<div class="block">Clears the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchema--">clearMessageSchema</a></span>()</code>
+<div class="block">Clears the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 <tr id="i5" class="rowColor">
@@ -197,8 +197,8 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 </tr>
 <tr id="i8" class="altColor">
 <td class="colFirst"><code><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#getMessageSchemaName--">getMessageSchemaName</a></span>()</code>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#getMessageSchema--">getMessageSchema</a></span>()</code>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 <tr id="i9" class="rowColor">
@@ -221,8 +221,8 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 </tr>
 <tr id="i12" class="altColor">
 <td class="colFirst"><code>boolean</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#hasMessageSchemaName--">hasMessageSchemaName</a></span>()</code>
-<div class="block">Checks whether the 'messageSchemaName' field has been set.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#hasMessageSchema--">hasMessageSchema</a></span>()</code>
+<div class="block">Checks whether the 'messageSchema' field has been set.</div>
 </td>
 </tr>
 <tr id="i13" class="rowColor">
@@ -245,8 +245,8 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 </tr>
 <tr id="i16" class="altColor">
 <td class="colFirst"><code><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchemaName-java.lang.CharSequence-">setMessageSchemaName</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchema-java.lang.CharSequence-">setMessageSchema</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 </table>
@@ -394,58 +394,58 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 </dl>
 </li>
 </ul>
-<a name="getMessageSchemaName--">
+<a name="getMessageSchema--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>getMessageSchemaName</h4>
-<pre>public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;getMessageSchemaName()</pre>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<h4>getMessageSchema</h4>
+<pre>public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;getMessageSchema()</pre>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>The value.</dd>
 </dl>
 </li>
 </ul>
-<a name="setMessageSchemaName-java.lang.CharSequence-">
+<a name="setMessageSchema-java.lang.CharSequence-">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>setMessageSchemaName</h4>
-<pre>public&nbsp;<a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a>&nbsp;setMessageSchemaName(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</pre>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<h4>setMessageSchema</h4>
+<pre>public&nbsp;<a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a>&nbsp;setMessageSchema(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</pre>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
-<dd><code>value</code> - The value of 'messageSchemaName'.</dd>
+<dd><code>value</code> - The value of 'messageSchema'.</dd>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>This builder.</dd>
 </dl>
 </li>
 </ul>
-<a name="hasMessageSchemaName--">
+<a name="hasMessageSchema--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>hasMessageSchemaName</h4>
-<pre>public&nbsp;boolean&nbsp;hasMessageSchemaName()</pre>
-<div class="block">Checks whether the 'messageSchemaName' field has been set.</div>
+<h4>hasMessageSchema</h4>
+<pre>public&nbsp;boolean&nbsp;hasMessageSchema()</pre>
+<div class="block">Checks whether the 'messageSchema' field has been set.</div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
-<dd>True if the 'messageSchemaName' field has been set, false otherwise.</dd>
+<dd>True if the 'messageSchema' field has been set, false otherwise.</dd>
 </dl>
 </li>
 </ul>
-<a name="clearMessageSchemaName--">
+<a name="clearMessageSchema--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>clearMessageSchemaName</h4>
-<pre>public&nbsp;<a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a>&nbsp;clearMessageSchemaName()</pre>
-<div class="block">Clears the value of the 'messageSchemaName' field.</div>
+<h4>clearMessageSchema</h4>
+<pre>public&nbsp;<a href="../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a>&nbsp;clearMessageSchema()</pre>
+<div class="block">Clears the value of the 'messageSchema' field.</div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
 <dd>This builder.</dd>
@@ -592,6 +592,6 @@ implements org.apache.avro.data.RecordBuilder&lt;<a href="../../../../com/financ
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/Transport.html
+++ b/doc/com/financialforce/orizuru/transport/Transport.html
@@ -184,7 +184,7 @@ implements org.apache.avro.specific.SpecificRecord</pre>
 </tr>
 <tr class="rowColor">
 <td class="colFirst"><code><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#messageSchemaName">messageSchemaName</a></span></code>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#messageSchema">messageSchema</a></span></code>
 <div class="block"><span class="deprecatedLabel">Deprecated.</span>&nbsp;</div>
 </td>
 </tr>
@@ -214,7 +214,7 @@ implements org.apache.avro.specific.SpecificRecord</pre>
 <tr class="rowColor">
 <td class="colOne"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#Transport-java.lang.CharSequence-java.nio.ByteBuffer-java.lang.CharSequence-java.nio.ByteBuffer-">Transport</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;contextSchema,
          <a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html?is-external=true" title="class or interface in java.nio">ByteBuffer</a>&nbsp;contextBuffer,
-         <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;messageSchemaName,
+         <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;messageSchema,
          <a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html?is-external=true" title="class or interface in java.nio">ByteBuffer</a>&nbsp;messageBuffer)</code>
 <div class="block">All-args constructor.</div>
 </td>
@@ -262,8 +262,8 @@ implements org.apache.avro.specific.SpecificRecord</pre>
 </tr>
 <tr id="i5" class="rowColor">
 <td class="colFirst"><code><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a></code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#getMessageSchemaName--">getMessageSchemaName</a></span>()</code>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#getMessageSchema--">getMessageSchema</a></span>()</code>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 <tr id="i6" class="altColor">
@@ -317,8 +317,8 @@ implements org.apache.avro.specific.SpecificRecord</pre>
 </tr>
 <tr id="i15" class="rowColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#setMessageSchemaName-java.lang.CharSequence-">setMessageSchemaName</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><code><span class="memberNameLink"><a href="../../../../com/financialforce/orizuru/transport/Transport.html#setMessageSchema-java.lang.CharSequence-">setMessageSchema</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 <tr id="i16" class="altColor">
@@ -385,14 +385,14 @@ public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffe
 <div class="block"><span class="deprecatedLabel">Deprecated.</span>&nbsp;</div>
 </li>
 </ul>
-<a name="messageSchemaName">
+<a name="messageSchema">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>messageSchemaName</h4>
+<h4>messageSchema</h4>
 <pre><a href="http://docs.oracle.com/javase/8/docs/api/java/lang/Deprecated.html?is-external=true" title="class or interface in java.lang">@Deprecated</a>
-public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a> messageSchemaName</pre>
+public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a> messageSchema</pre>
 <div class="block"><span class="deprecatedLabel">Deprecated.</span>&nbsp;</div>
 </li>
 </ul>
@@ -435,14 +435,14 @@ public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffe
 <h4>Transport</h4>
 <pre>public&nbsp;Transport(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;contextSchema,
                  <a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html?is-external=true" title="class or interface in java.nio">ByteBuffer</a>&nbsp;contextBuffer,
-                 <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;messageSchemaName,
+                 <a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;messageSchema,
                  <a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffer.html?is-external=true" title="class or interface in java.nio">ByteBuffer</a>&nbsp;messageBuffer)</pre>
 <div class="block">All-args constructor.</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>contextSchema</code> - The new value for contextSchema</dd>
 <dd><code>contextBuffer</code> - The new value for contextBuffer</dd>
-<dd><code>messageSchemaName</code> - The new value for messageSchemaName</dd>
+<dd><code>messageSchema</code> - The new value for messageSchema</dd>
 <dd><code>messageBuffer</code> - The new value for messageBuffer</dd>
 </dl>
 </li>
@@ -566,28 +566,28 @@ public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffe
 </dl>
 </li>
 </ul>
-<a name="getMessageSchemaName--">
+<a name="getMessageSchema--">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>getMessageSchemaName</h4>
-<pre>public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;getMessageSchemaName()</pre>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<h4>getMessageSchema</h4>
+<pre>public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;getMessageSchema()</pre>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 <dl>
 <dt><span class="returnLabel">Returns:</span></dt>
-<dd>The value of the 'messageSchemaName' field.</dd>
+<dd>The value of the 'messageSchema' field.</dd>
 </dl>
 </li>
 </ul>
-<a name="setMessageSchemaName-java.lang.CharSequence-">
+<a name="setMessageSchema-java.lang.CharSequence-">
 <!--   -->
 </a>
 <ul class="blockList">
 <li class="blockList">
-<h4>setMessageSchemaName</h4>
-<pre>public&nbsp;void&nbsp;setMessageSchemaName(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</pre>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<h4>setMessageSchema</h4>
+<pre>public&nbsp;void&nbsp;setMessageSchema(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</pre>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 <dl>
 <dt><span class="paramLabel">Parameters:</span></dt>
 <dd><code>value</code> - the value to set.</dd>
@@ -773,6 +773,6 @@ public&nbsp;<a href="http://docs.oracle.com/javase/8/docs/api/java/nio/ByteBuffe
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/class-use/Transport.Builder.html
+++ b/doc/com/financialforce/orizuru/transport/class-use/Transport.Builder.html
@@ -124,8 +124,8 @@
 </tr>
 <tr class="rowColor">
 <td class="colFirst"><code><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></code></td>
-<td class="colLast"><span class="typeNameLabel">Transport.Builder.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchemaName--">clearMessageSchemaName</a></span>()</code>
-<div class="block">Clears the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><span class="typeNameLabel">Transport.Builder.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchema--">clearMessageSchema</a></span>()</code>
+<div class="block">Clears the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 <tr class="altColor">
@@ -166,8 +166,8 @@
 </tr>
 <tr class="altColor">
 <td class="colFirst"><code><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></code></td>
-<td class="colLast"><span class="typeNameLabel">Transport.Builder.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchemaName-java.lang.CharSequence-">setMessageSchemaName</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<td class="colLast"><span class="typeNameLabel">Transport.Builder.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchema-java.lang.CharSequence-">setMessageSchema</a></span>(<a href="http://docs.oracle.com/javase/8/docs/api/java/lang/CharSequence.html?is-external=true" title="class or interface in java.lang">CharSequence</a>&nbsp;value)</code>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 </td>
 </tr>
 </tbody>
@@ -239,6 +239,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/class-use/Transport.html
+++ b/doc/com/financialforce/orizuru/transport/class-use/Transport.html
@@ -112,14 +112,14 @@
 <tbody>
 <tr class="altColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><span class="typeNameLabel">Message.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/message/Message.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
-<div class="block">Decode the message from the transport.</div>
+<td class="colLast"><span class="typeNameLabel">Context.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/message/Context.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
+<div class="block">Decode the context from the transport.</div>
 </td>
 </tr>
 <tr class="rowColor">
 <td class="colFirst"><code>void</code></td>
-<td class="colLast"><span class="typeNameLabel">Context.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/message/Context.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
-<div class="block">Decode the context from the transport.</div>
+<td class="colLast"><span class="typeNameLabel">Message.</span><code><span class="memberNameLink"><a href="../../../../../com/financialforce/orizuru/message/Message.html#decodeFromTransport-com.financialforce.orizuru.transport.Transport-">decodeFromTransport</a></span>(<a href="../../../../../com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a>&nbsp;input)</code>
+<div class="block">Decode the message from the transport.</div>
 </td>
 </tr>
 </tbody>
@@ -209,6 +209,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/package-summary.html
+++ b/doc/com/financialforce/orizuru/transport/package-summary.html
@@ -155,6 +155,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/package-tree.html
+++ b/doc/com/financialforce/orizuru/transport/package-tree.html
@@ -146,6 +146,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/com/financialforce/orizuru/transport/package-use.html
+++ b/doc/com/financialforce/orizuru/transport/package-use.html
@@ -181,6 +181,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/constant-values.html
+++ b/doc/constant-values.html
@@ -120,6 +120,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/deprecated-list.html
+++ b/doc/deprecated-list.html
@@ -97,7 +97,7 @@
 <td class="colOne"><a href="com/financialforce/orizuru/transport/Transport.html#messageBuffer">com.financialforce.orizuru.transport.Transport.messageBuffer</a></td>
 </tr>
 <tr class="rowColor">
-<td class="colOne"><a href="com/financialforce/orizuru/transport/Transport.html#messageSchemaName">com.financialforce.orizuru.transport.Transport.messageSchemaName</a></td>
+<td class="colOne"><a href="com/financialforce/orizuru/transport/Transport.html#messageSchema">com.financialforce.orizuru.transport.Transport.messageSchema</a></td>
 </tr>
 </tbody>
 </table>
@@ -151,6 +151,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/help-doc.html
+++ b/doc/help-doc.html
@@ -225,6 +225,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/index-all.html
+++ b/doc/index-all.html
@@ -112,9 +112,9 @@
 <dd>
 <div class="block">Clears the value of the 'messageBuffer' field.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchemaName--">clearMessageSchemaName()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#clearMessageSchema--">clearMessageSchema()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
 <dd>
-<div class="block">Clears the value of the 'messageSchemaName' field.</div>
+<div class="block">Clears the value of the 'messageSchema' field.</div>
 </dd>
 <dt><a href="com/financialforce/orizuru/package-summary.html">com.financialforce.orizuru</a> - package com.financialforce.orizuru</dt>
 <dd>
@@ -282,13 +282,13 @@
 <dd>
 <div class="block">Gets the value of the 'messageBuffer' field.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#getMessageSchemaName--">getMessageSchemaName()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#getMessageSchema--">getMessageSchema()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
 <dd>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#getMessageSchemaName--">getMessageSchemaName()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#getMessageSchema--">getMessageSchema()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
 <dd>
-<div class="block">Gets the value of the 'messageSchemaName' field.</div>
+<div class="block">Gets the value of the 'messageSchema' field.</div>
 </dd>
 <dt><span class="memberNameLink"><a href="com/financialforce/orizuru/AbstractConsumer.html#getQueueName--">getQueueName()</a></span> - Method in class com.financialforce.orizuru.<a href="com/financialforce/orizuru/AbstractConsumer.html" title="class in com.financialforce.orizuru">AbstractConsumer</a></dt>
 <dd>&nbsp;</dd>
@@ -299,8 +299,6 @@
 <dt><span class="memberNameLink"><a href="com/financialforce/orizuru/message/Message.html#getSchema--">getSchema()</a></span> - Method in class com.financialforce.orizuru.message.<a href="com/financialforce/orizuru/message/Message.html" title="class in com.financialforce.orizuru.message">Message</a></dt>
 <dd>&nbsp;</dd>
 <dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#getSchema--">getSchema()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
-<dd>&nbsp;</dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/message/Message.html#getSchemaName--">getSchemaName()</a></span> - Method in class com.financialforce.orizuru.message.<a href="com/financialforce/orizuru/message/Message.html" title="class in com.financialforce.orizuru.message">Message</a></dt>
 <dd>&nbsp;</dd>
 </dl>
 <a name="I:H">
@@ -330,9 +328,9 @@
 <dd>
 <div class="block">Checks whether the 'messageBuffer' field has been set.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#hasMessageSchemaName--">hasMessageSchemaName()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#hasMessageSchema--">hasMessageSchema()</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
 <dd>
-<div class="block">Checks whether the 'messageSchemaName' field has been set.</div>
+<div class="block">Checks whether the 'messageSchema' field has been set.</div>
 </dd>
 </dl>
 <a name="I:I">
@@ -374,7 +372,7 @@
 <dd>
 <div class="block"><span class="deprecatedLabel">Deprecated.</span></div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#messageSchemaName">messageSchemaName</a></span> - Variable in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#messageSchema">messageSchema</a></span> - Variable in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
 <dd>
 <div class="block"><span class="deprecatedLabel">Deprecated.</span></div>
 </dd>
@@ -488,13 +486,13 @@
 <dd>
 <div class="block">Sets the value of the 'messageBuffer' field.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchemaName-java.lang.CharSequence-">setMessageSchemaName(CharSequence)</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.Builder.html#setMessageSchema-java.lang.CharSequence-">setMessageSchema(CharSequence)</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.Builder.html" title="class in com.financialforce.orizuru.transport">Transport.Builder</a></dt>
 <dd>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 </dd>
-<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#setMessageSchemaName-java.lang.CharSequence-">setMessageSchemaName(CharSequence)</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
+<dt><span class="memberNameLink"><a href="com/financialforce/orizuru/transport/Transport.html#setMessageSchema-java.lang.CharSequence-">setMessageSchema(CharSequence)</a></span> - Method in class com.financialforce.orizuru.transport.<a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">Transport</a></dt>
 <dd>
-<div class="block">Sets the value of the 'messageSchemaName' field.</div>
+<div class="block">Sets the value of the 'messageSchema' field.</div>
 </dd>
 </dl>
 <a name="I:T">
@@ -573,6 +571,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/overview-summary.html
+++ b/doc/overview-summary.html
@@ -201,6 +201,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/overview-tree.html
+++ b/doc/overview-tree.html
@@ -198,6 +198,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/doc/serialized-form.html
+++ b/doc/serialized-form.html
@@ -203,7 +203,7 @@
 <h3>Class <a href="com/financialforce/orizuru/transport/Transport.html" title="class in com.financialforce.orizuru.transport">com.financialforce.orizuru.transport.Transport</a> extends org.apache.avro.specific.SpecificRecordBase implements Serializable</h3>
 <dl class="nameValue">
 <dt>serialVersionUID:</dt>
-<dd>7817005355469239244L</dd>
+<dd>145440526809843247L</dd>
 </dl>
 <ul class="blockList">
 <li class="blockList">
@@ -282,6 +282,6 @@
 <!--   -->
 </a></div>
 <!-- ======== END OF BOTTOM NAVBAR ======= -->
-<p class="legalCopy"><small>Copyright &#169; 2017. All rights reserved.</small></p>
+<p class="legalCopy"><small>Copyright &#169; 2018. All rights reserved.</small></p>
 </body>
 </html>

--- a/src/config/java.header
+++ b/src/config/java.header
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/AbstractConsumer.java
+++ b/src/main/java/com/financialforce/orizuru/AbstractConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/AbstractPublisher.java
+++ b/src/main/java/com/financialforce/orizuru/AbstractPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/AbstractPublisher.java
+++ b/src/main/java/com/financialforce/orizuru/AbstractPublisher.java
@@ -89,10 +89,10 @@ public abstract class AbstractPublisher<O extends GenericContainer> implements I
 			Message outgoingMessage = new Message();
 			outgoingMessage.encode(message);
 
-			CharSequence messageSchemaName = outgoingMessage.getSchemaName();
+			CharSequence messageSchema = outgoingMessage.getSchema().toString();
 			ByteBuffer messageBuffer = outgoingMessage.getDataBuffer();
 
-			return writeTransport(contextSchema, contextBuffer, messageSchemaName, messageBuffer);
+			return writeTransport(contextSchema, contextBuffer, messageSchema, messageBuffer);
 
 		} catch (OrizuruPublisherException ex) {
 			throw ex;

--- a/src/main/java/com/financialforce/orizuru/exception/OrizuruException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/OrizuruException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/OrizuruConsumerException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/OrizuruConsumerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeContextException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeContextException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageContentException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageContentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeMessageException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeTransportException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/decode/DecodeTransportException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/decode/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/decode/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/handler/HandleMessageException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/handler/HandleMessageException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/handler/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/handler/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/consumer/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/consumer/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/publisher/OrizuruPublisherException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/publisher/OrizuruPublisherException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/publisher/encode/EncodeMessageContentException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/publisher/encode/EncodeMessageContentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/publisher/encode/EncodeTransportException.java
+++ b/src/main/java/com/financialforce/orizuru/exception/publisher/encode/EncodeTransportException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/publisher/encode/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/publisher/encode/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/exception/publisher/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/exception/publisher/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/interfaces/IConsumer.java
+++ b/src/main/java/com/financialforce/orizuru/interfaces/IConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/interfaces/IPublisher.java
+++ b/src/main/java/com/financialforce/orizuru/interfaces/IPublisher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/interfaces/IQueueable.java
+++ b/src/main/java/com/financialforce/orizuru/interfaces/IQueueable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/interfaces/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/interfaces/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/message/Context.java
+++ b/src/main/java/com/financialforce/orizuru/message/Context.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/message/Message.java
+++ b/src/main/java/com/financialforce/orizuru/message/Message.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/message/Message.java
+++ b/src/main/java/com/financialforce/orizuru/message/Message.java
@@ -27,7 +27,6 @@
 package com.financialforce.orizuru.message;
 
 import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Constructor;
 import java.nio.ByteBuffer;
 
 import org.apache.avro.Schema;
@@ -108,13 +107,10 @@ public class Message {
 	public void decodeFromTransport(Transport input) throws OrizuruConsumerException {
 
 		try {
-
-			String messageSchemaName = input.getMessageSchemaName().toString();
-
-			Class<?> avroClass = Class.forName(messageSchemaName);
-			Constructor<?> constructor = avroClass.getConstructor();
-			GenericContainer container = (GenericContainer) constructor.newInstance();
-			this.schema = container.getSchema();
+		
+			String messageSchemaStr = input.getMessageSchema().toString();
+			Schema.Parser parser = new Schema.Parser();
+			this.schema = parser.parse(messageSchemaStr);
 
 			ByteBuffer messageBuffer = input.getMessageBuffer();
 			this.data = messageBuffer.array();
@@ -158,13 +154,6 @@ public class Message {
 	 */
 	public byte[] getData() {
 		return data;
-	}
-
-	/**
-	 * @return the schema name
-	 */
-	public CharSequence getSchemaName() {
-		return schema.getFullName();
 	}
 
 	/**

--- a/src/main/java/com/financialforce/orizuru/message/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/message/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/java/com/financialforce/orizuru/transport/package-info.java
+++ b/src/main/java/com/financialforce/orizuru/transport/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/main/resources/schema/avro/transport.avsc
+++ b/src/main/resources/schema/avro/transport.avsc
@@ -5,7 +5,7 @@
 	"fields": [
 		{ "name": "contextSchema", "type": "string" },
 		{ "name": "contextBuffer", "type": "bytes" },
-		{ "name": "messageSchemaName", "type": "string" },
+		{ "name": "messageSchema", "type": "string" },
 		{ "name": "messageBuffer", "type": "bytes" }
 	]
 }

--- a/src/test/java/com/financialforce/orizuru/AbstractConsumerTest.java
+++ b/src/test/java/com/financialforce/orizuru/AbstractConsumerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/test/java/com/financialforce/orizuru/AbstractConsumerTest.java
+++ b/src/test/java/com/financialforce/orizuru/AbstractConsumerTest.java
@@ -33,7 +33,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.apache.avro.Schema;
+import java.util.Base64;
+
 import org.apache.avro.generic.GenericContainer;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Rule;
@@ -49,7 +50,8 @@ import com.financialforce.orizuru.message.Context;
 
 public class AbstractConsumerTest {
 
-	private static final String VALID_MESSAGE = "V{\"name\":\"test\",\"type\":\"record\",\"fields\":[]}{}tcom.financialforce.orizuru.AbstractConsumerTest$TestSchematestData";
+	private static final String VALID_MESSAGE = "VnsidHlwZSI6InJlY29yZCIsIm5hbWUiOiJ0ZXN0IiwiZmllbGRzIjpbXX0Ee32oAnsidHlwZSI6InJlY29yZCIsIm5hbWUiOiJUZXN0U2NoZW1hIi"
+			+ "wibmFtZXNwYWNlIjoiY29tLmZpbmFuY2lhbGZvcmNlLm9yaXp1cnUuQWJzdHJhY3RDb25zdW1lclRlc3QiLCJmaWVsZHMiOlt7Im5hbWUiOiJ0ZXN0U3RyaW5nIiwidHlwZSI6InN0cmluZyJ9XX0KCHRlc3Q";
 
 	private static final String QUEUE_NAME = "testQueue";
 
@@ -77,7 +79,7 @@ public class AbstractConsumerTest {
 		Consumer consumer = new Consumer(QUEUE_NAME);
 		consumer.setPublisher(publisher);
 
-		byte[] body = VALID_MESSAGE.getBytes();
+		byte[] body = Base64.getDecoder().decode(VALID_MESSAGE.getBytes());
 
 		// when
 		consumer.consume(body);
@@ -91,7 +93,7 @@ public class AbstractConsumerTest {
 	public void consume_shouldDecodeTheTransport() throws Exception {
 
 		// given
-		byte[] body = VALID_MESSAGE.getBytes();
+		byte[] body = Base64.getDecoder().decode(VALID_MESSAGE.getBytes());
 
 		IConsumer consumer = new Consumer(QUEUE_NAME);
 
@@ -128,7 +130,7 @@ public class AbstractConsumerTest {
 		exception.expectCause(IsInstanceOf.<Throwable>instanceOf(NullPointerException.class));
 
 		// given
-		byte[] body = VALID_MESSAGE.getBytes();
+		byte[] body = Base64.getDecoder().decode(VALID_MESSAGE.getBytes());
 
 		IConsumer consumer = new ErrorConsumer(QUEUE_NAME);
 
@@ -146,25 +148,12 @@ public class AbstractConsumerTest {
 		exception.expectCause(IsInstanceOf.<Throwable>instanceOf(NullPointerException.class));
 
 		// given
-		byte[] body = VALID_MESSAGE.getBytes();
+		byte[] body = Base64.getDecoder().decode(VALID_MESSAGE.getBytes());
 
 		IConsumer consumer = new ErrorConsumer2(QUEUE_NAME);
 
 		// when
 		consumer.consume(body);
-
-	}
-
-	public static class TestSchema implements GenericContainer {
-
-		public TestSchema() {
-		}
-
-		@Override
-		public Schema getSchema() {
-			return new Schema.Parser().parse(
-					"{\"type\":\"record\",\"name\":\"TestSchema\",\"namespace\":\"com.financialforce.orizuru.AbstractConsumerTest\",\"fields\":[]}");
-		}
 
 	}
 

--- a/src/test/java/com/financialforce/orizuru/AbstractPublisherTest.java
+++ b/src/test/java/com/financialforce/orizuru/AbstractPublisherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/test/java/com/financialforce/orizuru/message/ContextTest.java
+++ b/src/test/java/com/financialforce/orizuru/message/ContextTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/test/java/com/financialforce/orizuru/message/MessageTest.java
+++ b/src/test/java/com/financialforce/orizuru/message/MessageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/test/java/com/financialforce/orizuru/message/MessageTest.java
+++ b/src/test/java/com/financialforce/orizuru/message/MessageTest.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.util.Base64;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaParseException;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecordBuilder;
 import org.hamcrest.core.IsInstanceOf;
@@ -104,17 +105,17 @@ public class MessageTest {
 	}
 
 	@Test
-	public void decodeFromTransport_shouldThrowADecodeMessageExceptionWithAClassNotFoundExceptionIfTheMessageSchemaNameClassDoesNotExist()
+	public void decodeFromTransport_shouldThrowADecodeMessageExceptionWithASchemaParseExceptionIfTheSchemaIsInvalid()
 			throws Exception {
 
 		// expect
 		exception.expect(DecodeMessageException.class);
 		exception.expectMessage("Failed to consume message: Failed to decode message");
-		exception.expectCause(IsInstanceOf.<Throwable>instanceOf(ClassNotFoundException.class));
+		exception.expectCause(IsInstanceOf.<Throwable>instanceOf(SchemaParseException.class));
 
 		// given
 		Transport transport = new Transport();
-		transport.setMessageSchemaName("invalid");
+		transport.setMessageSchema("invalid");
 
 		Message message = new Message();
 
@@ -129,8 +130,10 @@ public class MessageTest {
 		// given
 		ByteBuffer expectedMessage = ByteBuffer.wrap("{\"name\":\"testName\"}".getBytes());
 
+		String schema = "{\"type\":\"record\",\"name\":\"TestSchema\",\"namespace\":\"com.financialforce.orizuru.AbstractConsumerTest\",\"fields\":[{\"name\":\"testString\",\"type\":\"string\"}]}";
+		
 		Transport transport = new Transport();
-		transport.setMessageSchemaName("com.financialforce.orizuru.util.TestMessage");
+		transport.setMessageSchema(schema);
 		transport.setMessageBuffer(expectedMessage);
 
 		Message message = new Message();
@@ -192,22 +195,6 @@ public class MessageTest {
 
 		// when/then
 		assertEquals(schema, message.getSchema());
-
-	}
-
-	@Test
-	public void getSchemaName_shouldReturnTheMessageSchemaName() throws Exception {
-
-		// given
-		String expectedSchemaName = "com.financialforce.orizuru.util.TestMessage";
-
-		TestMessage testMessage = new TestMessage();
-		Schema schema = testMessage.getSchema();
-
-		Message message = new Message(schema, null);
-
-		// when/then
-		assertEquals(expectedSchemaName, message.getSchemaName());
 
 	}
 

--- a/src/test/java/com/financialforce/orizuru/util/TestMessage.java
+++ b/src/test/java/com/financialforce/orizuru/util/TestMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017, FinancialForce.com, inc
+ * Copyright (c) 2017-2018, FinancialForce.com, inc
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
- Update Orizuru Java to be compatible with the latest version of Orizuru.
	- The transport schema has reverted back to containing the full message schema rather than the name of the schema. This library has been updated to be compatible with this change.
	- Most of the changes below are changes to the copyright notice in the documentation.